### PR TITLE
Epsilon Prior is incorrect

### DIFF
--- a/CPM_Toolbox/model_functions/cpm_obv_int.m
+++ b/CPM_Toolbox/model_functions/cpm_obv_int.m
@@ -38,7 +38,7 @@ function [pE,pC] = observation_priors()
 
 pE.transit= 0 ;
 pE.decay= 0 ;
-pE.epsilon= 0.4584;
+pE.epsilon= -0.78;
 
 pC.transit= 1/128;
 pC.decay= 1/128;


### PR DESCRIPTION
The epsilon prior is incorrect (at least when compared to spm_prf_analyse) and Heinzle 2016. Additionally, `observation_priors` overwrites `spm_prf_analyze` with regards to the HRF priors and does not account for field strength anymore (`M.B0`).